### PR TITLE
Search input as type=search + cancel button handler. Should solve #118

### DIFF
--- a/app/templates/Homepage/default.latte
+++ b/app/templates/Homepage/default.latte
@@ -32,7 +32,7 @@
 	{/if}
 
 	<label for="search-query" class="hide">Search: </label>
-	<input type="text" name="query" id="search-query" class="addons-search input-full input-large" autofocus placeholder="type to search" class="hide">
+	<input type="search" name="query" id="search-query" class="addons-search input-full input-large" autofocus placeholder="type to search" class="hide">
 
 	<div class="addons-categorized-list">
 		{foreach $categories as $category}

--- a/www/js/addons.js
+++ b/www/js/addons.js
@@ -77,7 +77,7 @@ $(document).ready(function() {
 			}
 		});
 
-		$searchInput.keyup(function(e) {
+		var searchCallback = function(e) {
 			var query = $.trim(e.target.value).toLowerCase();
 			if (query.length === 0) {
 				$list.show();
@@ -100,7 +100,9 @@ $(document).ready(function() {
 					odd = !odd;
 				});
 			}
-		});
+		};
+		$searchInput.keyup(searchCallback);		
+		$searchInput.bind('search', searchCallback);
 
 		$('#categories-list').find('a').click(function() {
 			$searchInput.val('').keyup();


### PR DESCRIPTION
There exists an event 'search' which is fired by pressing Enter or clicking on "Cancel button" (a small cross i.e. in Chrome) for inputs of type='search'. I suggest handling this event with the same callback as the 'keyup' event which would lead in the expected behaviour as the whole list of addons would be shown after clicking on the "Cancel button".
