### PR TITLE
BasePresenter: removed assigned $pages to template

### DIFF
--- a/app/presenters/BasePresenter.php
+++ b/app/presenters/BasePresenter.php
@@ -213,6 +213,5 @@ abstract class BasePresenter extends \Nette\Application\UI\Presenter
 		$this->template->auth = $this->auth;
 		$this->template->categories = $this->tags->findMainTags();
 		$this->template->tags = $this->tags;
-		$this->template->pages = $this->pages->findAll();
 	}
 }


### PR DESCRIPTION
Fixes 'Cannot read an undeclared property NetteAddons\SignPresenter::$pages.'
