### PR TITLE
GitHubImporter: fixed APIv3 compatibility

### DIFF
--- a/app/model/Importers/GitHubImporter.php
+++ b/app/model/Importers/GitHubImporter.php
@@ -79,12 +79,12 @@ class GitHubImporter extends \Nette\Object implements IAddonImporter
 	public function import()
 	{
 		$info = $this->repository->getMetadata();
-		if (!isset($info->master_branch, $info->name, $info->description)) {
+		if (!isset($info->default_branch, $info->name, $info->description)) {
 			throw new \NetteAddons\IOException('GitHub returned invalid response.');
 		}
 
-		$readme = $this->repository->getReadme($info->master_branch);
-		$composer = $this->getComposerJson($info->master_branch);
+		$readme = $this->repository->getReadme($info->default_branch);
+		$composer = $this->getComposerJson($info->default_branch);
 
 		$addon = new Addon();
 

--- a/tests/cases/model/Importers/GitHubImporterTest.phpt
+++ b/tests/cases/model/Importers/GitHubImporterTest.phpt
@@ -44,7 +44,7 @@ class GitHubImporterTest extends TestCase
 		$this->repo->shouldReceive('getMetadata')
 			->withNoArgs()->once()
 			->andReturn((object) array(
-				'master_branch' => 'work_br',
+				'default_branch' => 'work_br',
 				'name' => 'gh-name',
 				'description' => 'gh-desc',
 			));
@@ -95,7 +95,7 @@ class GitHubImporterTest extends TestCase
 		$this->repo->shouldReceive('getMetadata')
 			->withNoArgs()->once()
 			->andReturn((object) array(
-				'master_branch' => 'work_br',
+				'default_branch' => 'work_br',
 				'name' => 'gh-name',
 				'description' => 'gh-desc',
 			));
@@ -136,7 +136,7 @@ class GitHubImporterTest extends TestCase
 		$this->repo->shouldReceive('getMetadata')
 			->withNoArgs()->once()
 			->andReturn((object) array(
-				'master_branch' => 'work_br',
+				'default_branch' => 'work_br',
 				'name' => 'gh-name',
 				'description' => '',
 			));


### PR DESCRIPTION
GitHub deployed APIv3 recently. This fixes compatibility with old beta: https://developer.github.com/v3/versions/#repository-json
